### PR TITLE
Fix blogs.js ESLint warning

### DIFF
--- a/src/services/blogs.js
+++ b/src/services/blogs.js
@@ -6,4 +6,6 @@ const getAll = () => {
   return request.then(response => response.data)
 }
 
-export default { getAll }
+const blogService = { getAll }
+
+export default blogService


### PR DESCRIPTION
Create React App 5.0 has updated eslint rules and objects need to be assigned to a variable before exporting or you get a warning.